### PR TITLE
Add Image Optimization Subcommand for Slide Builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "slide-flow"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slide-flow"
-version = "0.4.0"
+version = "0.4.1"
 description = "A CLI tool for managing Marp markdown slide presentations."
 authors = ["Kenta Komoto"]
 license = "MIT"

--- a/docs/20260601-optimize-images.md
+++ b/docs/20260601-optimize-images.md
@@ -1,0 +1,245 @@
+方針としては，`slide-flow build` の内部に「画像最適化ステージ」を追加しつつ，単体でも実行できる `slide-flow images optimize` を用意するのがよいです．
+
+つまり，通常利用では次の流れにします．
+
+```txt
+slide-flow build slide.md
+
+1. slide.md を読む
+2. 参照されている画像を収集する
+3. 画像をキャッシュディレクトリへ最適化する
+4. 一時的なビルド用 Markdown / assets を作る
+5. Marp で HTML / PDF / OGP を生成する
+6. 公開用ディレクトリへ配置する
+```
+
+ポイントは，元画像を直接書き換えないことです．スライド用画像は，あとから再編集したり，高解像度版を残したりすることが多いので，`assets/` 以下の原本は保持し，`target/slide-flow/assets/` や `.slide-flow/cache/` に最適化済み画像を出す設計が安全です．
+
+ディレクトリは次のようにすると扱いやすいです．
+
+```txt
+slides/
+├── sources/
+│   ├── talk.md
+│   └── assets/
+│       ├── graph.png
+│       ├── diagram.svg
+│       └── photo.jpg
+├── .slide-flow/
+│   └── cache/
+│       └── images/
+│           ├── <hash>.png
+│           ├── <hash>.svg
+│           └── <hash>.jpg
+└── public/
+    └── ...
+```
+
+`build` 時には，`talk.md` 内の画像参照を解析して，ビルド用の一時 Markdown を作ります．たとえば元の Markdown が次のような場合です．
+
+```md
+![graph](./assets/graph.png)
+<img src="./assets/diagram.svg" />
+```
+
+内部では，一時ファイル上だけ次のように差し替えます．
+
+```md
+![graph](../.slide-flow/cache/images/<hash>.png)
+<img src="../.slide-flow/cache/images/<hash>.svg" />
+```
+
+これにより，Marp が HTML や PDF を作る時点で最適化済み画像を参照できます．「ビルド前に実行」という要望にはこの形が一番合います．
+
+CLI は次のように分けるとよいです．
+
+```txt
+slide-flow build <source>
+slide-flow build-all
+
+slide-flow images optimize <source>
+slide-flow images optimize-all
+slide-flow images check <source>
+slide-flow images clean
+```
+
+`slide-flow build` はデフォルトで画像最適化を実行します．一方で，デバッグや差分確認のために次も用意します．
+
+```txt
+slide-flow build talk.md --no-optimize-images
+slide-flow images optimize talk.md --dry-run
+slide-flow images optimize talk.md --force
+```
+
+`--dry-run` では，「どの画像が対象になるか」「何 byte 減る見込みか」「どのツールが使われるか」だけを表示します．`--force` はキャッシュを無視して再最適化します．
+
+設定ファイルは，最初はこのくらいで十分です．
+
+```toml
+[images]
+enabled = true
+cache_dir = ".slide-flow/cache/images"
+mode = "lossless"
+strip_metadata = true
+fail_on_missing_tool = false
+
+[images.png]
+enabled = true
+tool = "oxipng"
+level = 4
+
+[images.jpeg]
+enabled = true
+tool = "jpegoptim"
+quality = 85
+
+[images.svg]
+enabled = true
+tool = "svgo"
+
+[images.webp]
+enabled = false
+```
+
+ただし，`mode = "lossless"` をデフォルトにするのが無難です．スライドでは図，スクリーンショット，数式画像などが多く，勝手に画質を落とすと困ることがあります．JPEG だけ `quality = 85` のような lossy 圧縮を許す場合は，明示的に `mode = "lossy"` を指定する形がよいです．
+
+画像形式ごとの扱いは次の方針がよいです．
+
+```txt
+PNG  -> oxipng
+JPEG -> jpegoptim
+SVG  -> svgo
+WebP -> 初期実装ではコピーのみ，後から対応
+AVIF -> 初期実装では非対応
+GIF  -> 初期実装ではコピーのみ
+```
+
+`oxipng` は PNG/APNG の lossless 最適化用の CLI / Rust ライブラリで，macOS / Linux ではパッケージマネージャや Cargo から入れる方針が案内されています．([GitHub][1]) `jpegoptim` は JPEG の最適化・圧縮用ユーティリティです．([GitHub][2]) `svgo` は SVG 最適化用の Node.js ライブラリ兼 CLI で，`npm install -g svgo` などで導入できます．([GitHub][3])
+
+Ubuntu / macOS 両対応を考えると，最初から全 optimizer を Rust に組み込むより，外部コマンドとして呼ぶ設計が素直です．`slide-flow doctor` で依存コマンドの有無を確認できるようにします．
+
+```txt
+slide-flow doctor
+
+marp       ok
+oxipng     ok
+jpegoptim  missing
+svgo       ok
+```
+
+`fail_on_missing_tool = false` の場合，未インストールの optimizer があっても，その形式の画像はそのままコピーしてビルドを継続します．これは個人用ツールとして使いやすいです．CI では `fail_on_missing_tool = true` にするとよいです．
+
+Rust 側の構成は，たとえば次のように分けます．
+
+```txt
+src/
+├── main.rs
+├── cli.rs
+├── config.rs
+├── build/
+│   ├── mod.rs
+│   ├── pipeline.rs
+│   └── marp.rs
+├── images/
+│   ├── mod.rs
+│   ├── collect.rs
+│   ├── cache.rs
+│   ├── optimizer.rs
+│   ├── rewrite.rs
+│   └── report.rs
+└── fs.rs
+```
+
+`images::collect` は Markdown / HTML 風の画像参照を集めます．最初は Markdown の `![](...)` と `<img src="...">` だけ対応すればよいです．CSS の `background-image` まで追うのは後回しでよいです．
+
+`images::cache` は入力ファイルのパス，更新時刻，サイズ，optimizer 設定をもとにキャッシュキーを作ります．より堅くするならファイル内容のハッシュを使います．
+
+```txt
+cache key = hash(
+  absolute source path,
+  file content hash,
+  optimizer kind,
+  optimizer options
+)
+```
+
+これにより，画像が変わっていない場合は最適化をスキップできます．同じスライドを何度もビルドするときに効きます．
+
+`images::optimizer` は次のような trait にすると拡張しやすいです．
+
+```rust
+pub trait ImageOptimizer {
+    fn supports(&self, ext: &str) -> bool;
+    fn optimize(&self, input: &Path, output: &Path, options: &ImageOptions) -> Result<OptimizeResult>;
+}
+```
+
+ただし，これはやや抽象化が早い可能性があります．初期実装では `match ext` で `Command` を呼ぶだけでも十分です．将来 WebP / AVIF / 自前 Rust 実装を入れたいなら trait 化，まず動かすなら `match` でよいです．
+
+ビルドパイプラインとしては，次の順序がよいです．
+
+```txt
+BuildPipeline
+  -> resolve slide metadata
+  -> collect image refs
+  -> optimize images into cache
+  -> generate staged markdown
+  -> run marp html
+  -> run marp pdf
+  -> generate ogp
+  -> write redirects
+```
+
+ここで重要なのは，OGP 用画像の最適化は別扱いにすることです．スライド内で使う画像は「ビルド前」に最適化しますが，OGP 画像は Marp などで生成された後にできるので，「ビルド後」に最適化します．したがって，画像最適化は厳密には 2 種類あります．
+
+```txt
+pre-build image optimization
+  スライド本文が参照する画像を最適化する
+
+post-build image optimization
+  生成された OGP 画像やサムネイルを最適化する
+```
+
+設定上も分けられるようにしておくとよいです．
+
+```toml
+[images.pre_build]
+enabled = true
+
+[images.post_build]
+enabled = true
+targets = ["ogp"]
+```
+
+最初の MVP は次で十分です．
+
+```txt
+1. Markdown の画像参照を収集
+2. PNG / JPEG / SVG を対象にする
+3. 元画像は変更しない
+4. `.slide-flow/cache/images` に最適化済み画像を生成
+5. 一時 Markdown の参照先を差し替えて Marp を実行
+6. `--no-optimize-images` と `--dry-run` を用意
+7. `doctor` で依存コマンドを確認
+```
+
+この設計なら，Ubuntu / macOS の差はほぼ「外部コマンドのインストール方法」だけになります．`slide-flow` 本体は Rust で共通にし，optimizer は PATH 上のコマンドとして呼び出すのが一番実装しやすいです．
+
+README には次のように書ける形を目標にするとよいです．
+
+```bash
+# Ubuntu
+sudo apt install oxipng jpegoptim
+npm install -g svgo
+
+# macOS
+brew install oxipng jpegoptim
+npm install -g svgo
+```
+
+ただし，パッケージ名や提供状況は環境で変わる可能性があるので，`slide-flow doctor` で最終確認する運用にしておくのが安全です．
+
+[1]: https://github.com/shssoichiro/oxipng "GitHub - oxipng/oxipng: Multithreaded PNG optimizer written in Rust · GitHub"
+[2]: https://github.com/tjko/jpegoptim "GitHub - tjko/jpegoptim: jpegoptim - utility to optimize/compress JPEG files · GitHub"
+[3]: https://github.com/svg/svgo "GitHub - svg/svgo: ⚙️ Node.js tool for optimizing SVG files · GitHub"
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,9 @@ pub struct ProjectConf {
     pub template: TemplateConf,
     /// build configuration
     pub build: BuildConf,
+    /// image optimization configuration
+    #[serde(default)]
+    pub images: ImagesConf,
 }
 
 impl Default for ProjectConf {
@@ -30,8 +33,162 @@ impl Default for ProjectConf {
             output_dir: "output".to_string(),
             template: TemplateConf::default(),
             build: BuildConf::default(),
+            images: ImagesConf::default(),
         }
     }
+}
+
+/// image optimization configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImagesConf {
+    /// enable image optimization
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// cache directory relative to the project root
+    #[serde(default = "default_image_cache_dir")]
+    pub cache_dir: String,
+    /// optimization mode
+    #[serde(default)]
+    pub mode: ImageOptimizeMode,
+    /// strip metadata when supported by the optimizer
+    #[serde(default = "default_true")]
+    pub strip_metadata: bool,
+    /// fail instead of copying through when an optimizer is missing
+    #[serde(default)]
+    pub fail_on_missing_tool: bool,
+    /// PNG optimizer configuration
+    #[serde(default)]
+    pub png: PngImageConf,
+    /// JPEG optimizer configuration
+    #[serde(default)]
+    pub jpeg: JpegImageConf,
+    /// SVG optimizer configuration
+    #[serde(default)]
+    pub svg: SvgImageConf,
+    /// WebP handling configuration
+    #[serde(default)]
+    pub webp: WebpImageConf,
+}
+
+impl Default for ImagesConf {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cache_dir: default_image_cache_dir(),
+            mode: ImageOptimizeMode::Lossless,
+            strip_metadata: true,
+            fail_on_missing_tool: false,
+            png: PngImageConf::default(),
+            jpeg: JpegImageConf::default(),
+            svg: SvgImageConf::default(),
+            webp: WebpImageConf::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ImageOptimizeMode {
+    #[default]
+    Lossless,
+    Lossy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PngImageConf {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_oxipng")]
+    pub tool: String,
+    #[serde(default = "default_png_level")]
+    pub level: u8,
+}
+
+impl Default for PngImageConf {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            tool: default_oxipng(),
+            level: default_png_level(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JpegImageConf {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_jpegoptim")]
+    pub tool: String,
+    #[serde(default = "default_jpeg_quality")]
+    pub quality: u8,
+}
+
+impl Default for JpegImageConf {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            tool: default_jpegoptim(),
+            quality: default_jpeg_quality(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SvgImageConf {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_svgo")]
+    pub tool: String,
+}
+
+impl Default for SvgImageConf {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            tool: default_svgo(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebpImageConf {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for WebpImageConf {
+    fn default() -> Self {
+        Self { enabled: false }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_image_cache_dir() -> String {
+    ".slide-flow/cache/images".to_string()
+}
+
+fn default_oxipng() -> String {
+    "oxipng".to_string()
+}
+
+fn default_jpegoptim() -> String {
+    "jpegoptim".to_string()
+}
+
+fn default_svgo() -> String {
+    "svgo".to_string()
+}
+
+fn default_png_level() -> u8 {
+    4
+}
+
+fn default_jpeg_quality() -> u8 {
+    85
 }
 
 /// template configuration

--- a/src/images.rs
+++ b/src/images.rs
@@ -1,0 +1,432 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    fs,
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{anyhow, Context};
+use regex::{Captures, Regex};
+
+use crate::{
+    config::{ImageOptimizeMode, ImagesConf},
+    project::Project,
+    slide::Slide,
+};
+
+#[derive(Debug, Clone)]
+pub struct OptimizeOptions {
+    pub dry_run: bool,
+    pub force: bool,
+}
+
+pub enum ImageRewriteMode {
+    CacheRelativeToMarkdown,
+    PublicAssets { base_dir: PathBuf },
+}
+
+#[derive(Debug, Clone)]
+pub struct ImageRef {
+    original: String,
+    path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct OptimizedImage {
+    original: String,
+    source_path: PathBuf,
+    cache_path: PathBuf,
+    optimized: bool,
+    cached: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct OptimizeReport {
+    pub images: Vec<OptimizedImage>,
+    pub dry_run: bool,
+}
+
+impl OptimizeReport {
+    pub fn is_empty(&self) -> bool {
+        self.images.is_empty()
+    }
+
+    pub fn log(&self, slide: &Slide) {
+        if self.is_empty() {
+            log::info!(
+                "optimize images: {} ... no images",
+                slide.dir.to_string_lossy()
+            );
+            return;
+        }
+
+        let optimized = self.images.iter().filter(|image| image.optimized).count();
+        let cached = self.images.iter().filter(|image| image.cached).count();
+        log::info!(
+            "optimize images: {} ... {} image(s), {} optimized, {} cached",
+            slide.dir.to_string_lossy(),
+            self.images.len(),
+            optimized,
+            cached
+        );
+    }
+}
+
+impl OptimizedImage {
+    pub fn cache_path(&self) -> &Path {
+        &self.cache_path
+    }
+}
+
+pub fn optimize_slide_images(
+    project: &Project,
+    slide: &Slide,
+    options: &OptimizeOptions,
+) -> anyhow::Result<OptimizeReport> {
+    let markdown_path = slide.dir.join("slide.md");
+    let contents = fs::read_to_string(&markdown_path)?;
+    let refs = collect_image_refs(slide, &contents)?;
+    optimize_image_refs(project, slide, refs, options)
+}
+
+pub fn prepare_optimized_markdown(
+    project: &Project,
+    slide: &Slide,
+    contents: &str,
+    options: &OptimizeOptions,
+    rewrite_mode: ImageRewriteMode,
+) -> anyhow::Result<(String, OptimizeReport)> {
+    if !project.conf.images.enabled {
+        return Ok((contents.to_string(), OptimizeReport::default()));
+    }
+
+    let refs = collect_image_refs(slide, contents)?;
+    let report = optimize_image_refs(project, slide, refs, options)?;
+    let rewritten = rewrite_image_refs(contents, &slide.dir, &report.images, rewrite_mode)?;
+
+    Ok((rewritten, report))
+}
+
+pub fn clean_image_cache(project: &Project) -> anyhow::Result<PathBuf> {
+    let cache_dir = project.root_dir.join(&project.conf.images.cache_dir);
+
+    if cache_dir.exists() {
+        fs::remove_dir_all(&cache_dir)?;
+    }
+
+    Ok(cache_dir)
+}
+
+fn collect_image_refs(slide: &Slide, contents: &str) -> anyhow::Result<Vec<ImageRef>> {
+    let markdown = Regex::new(r#"!\[[^\]]*\]\((?P<url>[^)\s]+)(?:\s+"[^"]*")?\)"#)?;
+    let html = Regex::new(r#"<img\b[^>]*\bsrc=["'](?P<url>[^"']+)["'][^>]*>"#)?;
+    let mut refs = Vec::new();
+
+    for caps in markdown.captures_iter(contents) {
+        push_image_ref(slide, &mut refs, &caps)?;
+    }
+    for caps in html.captures_iter(contents) {
+        push_image_ref(slide, &mut refs, &caps)?;
+    }
+
+    refs.sort_by(|a, b| a.original.cmp(&b.original));
+    refs.dedup_by(|a, b| a.original == b.original);
+    Ok(refs)
+}
+
+fn push_image_ref(slide: &Slide, refs: &mut Vec<ImageRef>, caps: &Captures) -> anyhow::Result<()> {
+    let Some(url) = caps.name("url").map(|m| m.as_str()) else {
+        return Ok(());
+    };
+
+    if should_skip_url(url) {
+        return Ok(());
+    }
+
+    let path_part = url.split(['?', '#']).next().unwrap_or(url);
+    let path = slide.dir.join(path_part);
+    if !path.exists() || !path.is_file() {
+        return Ok(());
+    }
+
+    refs.push(ImageRef {
+        original: url.to_string(),
+        path,
+    });
+
+    Ok(())
+}
+
+fn should_skip_url(url: &str) -> bool {
+    url.starts_with("http://")
+        || url.starts_with("https://")
+        || url.starts_with("data:")
+        || url.starts_with('/')
+        || url.starts_with('#')
+}
+
+fn optimize_image_refs(
+    project: &Project,
+    slide: &Slide,
+    refs: Vec<ImageRef>,
+    options: &OptimizeOptions,
+) -> anyhow::Result<OptimizeReport> {
+    let cache_dir = project.root_dir.join(&project.conf.images.cache_dir);
+    if !options.dry_run {
+        fs::create_dir_all(&cache_dir)?;
+    }
+
+    let mut images = Vec::new();
+    for image_ref in refs {
+        let extension = image_ref
+            .path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let cache_path = cache_dir.join(format!(
+            "{}.{}",
+            cache_key(&image_ref.path, &project.conf.images, &extension)?,
+            extension
+        ));
+
+        let cached = cache_path.exists() && !options.force;
+        let mut optimized = false;
+
+        if !cached && !options.dry_run {
+            optimized = optimize_one(&project.conf.images, &image_ref.path, &cache_path)
+                .with_context(|| image_ref.path.to_string_lossy().to_string())?;
+        }
+
+        images.push(OptimizedImage {
+            original: image_ref.original,
+            source_path: image_ref.path,
+            cache_path,
+            optimized,
+            cached,
+        });
+    }
+
+    let report = OptimizeReport {
+        images,
+        dry_run: options.dry_run,
+    };
+    report.log(slide);
+    Ok(report)
+}
+
+fn cache_key(path: &Path, conf: &ImagesConf, extension: &str) -> anyhow::Result<String> {
+    let metadata = fs::metadata(path)?;
+    let modified = metadata.modified().ok();
+    let mut hasher = DefaultHasher::new();
+
+    path.canonicalize()?.hash(&mut hasher);
+    metadata.len().hash(&mut hasher);
+    modified.hash(&mut hasher);
+    extension.hash(&mut hasher);
+    conf.mode.hash(&mut hasher);
+    conf.strip_metadata.hash(&mut hasher);
+    conf.png.level.hash(&mut hasher);
+    conf.jpeg.quality.hash(&mut hasher);
+
+    Ok(format!("{:016x}", hasher.finish()))
+}
+
+fn optimize_one(conf: &ImagesConf, input: &Path, output: &Path) -> anyhow::Result<bool> {
+    let extension = input
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    match extension.as_str() {
+        "png" if conf.png.enabled => run_oxipng(conf, input, output),
+        "jpg" | "jpeg" if conf.jpeg.enabled => run_jpegoptim(conf, input, output),
+        "svg" if conf.svg.enabled => run_svgo(conf, input, output),
+        _ => {
+            fs::copy(input, output)?;
+            Ok(false)
+        }
+    }
+}
+
+fn run_oxipng(conf: &ImagesConf, input: &Path, output: &Path) -> anyhow::Result<bool> {
+    if !command_exists(&conf.png.tool) {
+        return missing_tool(conf, &conf.png.tool, input, output);
+    }
+
+    let mut cmd = Command::new(&conf.png.tool);
+    cmd.arg("-o")
+        .arg(conf.png.level.to_string())
+        .arg("--out")
+        .arg(output);
+
+    if conf.strip_metadata {
+        cmd.arg("--strip").arg("safe");
+    }
+
+    cmd.arg(input);
+    run_optimizer(cmd)?;
+    Ok(true)
+}
+
+fn run_jpegoptim(conf: &ImagesConf, input: &Path, output: &Path) -> anyhow::Result<bool> {
+    if !command_exists(&conf.jpeg.tool) {
+        return missing_tool(conf, &conf.jpeg.tool, input, output);
+    }
+
+    fs::copy(input, output)?;
+
+    let mut cmd = Command::new(&conf.jpeg.tool);
+    if conf.strip_metadata {
+        cmd.arg("--strip-all");
+    }
+    if conf.mode == ImageOptimizeMode::Lossy {
+        cmd.arg(format!("--max={}", conf.jpeg.quality));
+    }
+    cmd.arg(output);
+    run_optimizer(cmd)?;
+    Ok(true)
+}
+
+fn run_svgo(conf: &ImagesConf, input: &Path, output: &Path) -> anyhow::Result<bool> {
+    if !command_exists(&conf.svg.tool) {
+        return missing_tool(conf, &conf.svg.tool, input, output);
+    }
+
+    let mut cmd = Command::new(&conf.svg.tool);
+    cmd.arg(input).arg("-o").arg(output);
+    run_optimizer(cmd)?;
+    Ok(true)
+}
+
+fn missing_tool(
+    conf: &ImagesConf,
+    tool: &str,
+    input: &Path,
+    output: &Path,
+) -> anyhow::Result<bool> {
+    if conf.fail_on_missing_tool {
+        return Err(anyhow!("image optimizer is missing: {tool}"));
+    }
+
+    log::warn!(
+        "image optimizer is missing: {}; copy without optimization: {}",
+        tool,
+        input.to_string_lossy()
+    );
+    fs::copy(input, output)?;
+    Ok(false)
+}
+
+fn command_exists(command: &str) -> bool {
+    Command::new(command)
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn run_optimizer(mut command: Command) -> anyhow::Result<()> {
+    let output = command.output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "optimizer failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    ))
+}
+
+fn rewrite_image_refs(
+    contents: &str,
+    markdown_dir: &Path,
+    images: &[OptimizedImage],
+    rewrite_mode: ImageRewriteMode,
+) -> anyhow::Result<String> {
+    let mut rewritten = contents.to_string();
+
+    for image in images {
+        let relative = match &rewrite_mode {
+            ImageRewriteMode::CacheRelativeToMarkdown => {
+                relative_path(markdown_dir, &image.cache_path)
+            }
+            ImageRewriteMode::PublicAssets { base_dir } => {
+                let Some(file_name) = image.cache_path.file_name() else {
+                    continue;
+                };
+                base_dir.join(file_name)
+            }
+        };
+        let replacement = preserve_suffix(&image.original, &relative);
+        rewritten = rewritten.replace(&image.original, &replacement);
+    }
+
+    Ok(rewritten)
+}
+
+fn preserve_suffix(original: &str, replacement_path: &Path) -> String {
+    let suffix = original
+        .find(['?', '#'])
+        .map(|index| &original[index..])
+        .unwrap_or_default();
+
+    format!("{}{}", replacement_path.to_string_lossy(), suffix)
+}
+
+pub fn relative_path(from_dir: &Path, to_path: &Path) -> PathBuf {
+    let from_components: Vec<_> = from_dir.components().collect();
+    let to_components: Vec<_> = to_path.components().collect();
+    let common_len = from_components
+        .iter()
+        .zip(to_components.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let mut relative = PathBuf::new();
+    for _ in common_len..from_components.len() {
+        relative.push("..");
+    }
+    for component in &to_components[common_len..] {
+        relative.push(component.as_os_str());
+    }
+
+    if relative.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        relative
+    }
+}
+
+pub fn print_report(report: &OptimizeReport, project: &Project) {
+    if report.is_empty() {
+        println!("No images found.");
+        return;
+    }
+
+    for image in &report.images {
+        let action = if image.cached {
+            "cached"
+        } else if report.dry_run {
+            "would optimize"
+        } else if image.optimized {
+            "optimized"
+        } else {
+            "copied"
+        };
+        println!(
+            "{} -> {} ({action})",
+            display_path(project, &image.source_path),
+            display_path(project, &image.cache_path)
+        );
+    }
+}
+
+fn display_path(project: &Project, path: &Path) -> String {
+    path.strip_prefix(&project.root_dir)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod contents;
+pub mod images;
 pub mod parser;
 pub mod path;
 pub mod project;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,19 @@
 use clap::Parser;
 use slide_flow::{
     config::PathStrategy,
+    images::{clean_image_cache, optimize_slide_images, print_report, OptimizeOptions},
     parser::{
-        Cmd, MigrateCommands, SlidesCommands,
-        SubCommands::{Build, Init, Migrate, Slide},
+        Cmd, ImagesCommands, MigrateCommands, SlidesCommands,
+        SubCommands::{Build, Images, Init, Migrate, Slide},
     },
     project::Project,
     subcommand::{
         add::add,
         bib::update_bibliography,
         build::{
-            build, build_html_commands, build_ogp_image_commands, build_pdf_commands,
-            build_pdf_latest_alias_commands, copy_images_html, copy_ipe_pdf, write_alias_redirects,
+            build, build_html_commands_with_options, build_ogp_image_commands_with_options,
+            build_pdf_commands_with_options, build_pdf_latest_alias_commands_with_options,
+            copy_images_html_with_options, copy_ipe_pdf, write_alias_redirects,
         },
         index::put_index,
         init::init,
@@ -62,7 +64,13 @@ fn runner() -> anyhow::Result<()> {
         Build {
             directories,
             concurrent,
+            no_optimize_images,
         } => {
+            let optimize_options = OptimizeOptions {
+                dry_run: false,
+                force: false,
+            };
+            let optimize_images = !no_optimize_images;
             // generate build commands
             let mut cmds = vec![];
 
@@ -94,34 +102,55 @@ fn runner() -> anyhow::Result<()> {
                 }
 
                 // copy images
-                if let Err(e) = copy_images_html(&project, &target_slide) {
+                if let Err(e) =
+                    copy_images_html_with_options(&project, &target_slide, optimize_images)
+                {
                     log::error!("Failed to copy images: {}", e);
                     continue;
                 }
 
-                let build_html_cmd = match build_html_commands(&project, &target_slide) {
+                let build_html_cmd = match build_html_commands_with_options(
+                    &project,
+                    &target_slide,
+                    &optimize_options,
+                    optimize_images,
+                ) {
                     Ok(cmds) => cmds,
                     Err(e) => {
                         log::error!("Failed to prepare HTML build: {}", e);
                         continue;
                     }
                 };
-                let build_pdf_cmd = match build_pdf_commands(&project, &target_slide) {
+                let build_pdf_cmd = match build_pdf_commands_with_options(
+                    &project,
+                    &target_slide,
+                    &optimize_options,
+                    optimize_images,
+                ) {
                     Ok(cmds) => cmds,
                     Err(e) => {
                         log::error!("Failed to prepare PDF build: {}", e);
                         continue;
                     }
                 };
-                let build_pdf_latest_alias_cmd =
-                    match build_pdf_latest_alias_commands(&project, &target_slide) {
-                        Ok(cmds) => cmds,
-                        Err(e) => {
-                            log::error!("Failed to prepare latest PDF build: {}", e);
-                            continue;
-                        }
-                    };
-                let build_ogp_image_cmd = match build_ogp_image_commands(&project, &target_slide) {
+                let build_pdf_latest_alias_cmd = match build_pdf_latest_alias_commands_with_options(
+                    &project,
+                    &target_slide,
+                    &optimize_options,
+                    optimize_images,
+                ) {
+                    Ok(cmds) => cmds,
+                    Err(e) => {
+                        log::error!("Failed to prepare latest PDF build: {}", e);
+                        continue;
+                    }
+                };
+                let build_ogp_image_cmd = match build_ogp_image_commands_with_options(
+                    &project,
+                    &target_slide,
+                    &optimize_options,
+                    optimize_images,
+                ) {
                     Ok(cmds) => cmds,
                     Err(e) => {
                         log::error!("Failed to prepare OGP image build: {}", e);
@@ -146,7 +175,9 @@ fn runner() -> anyhow::Result<()> {
 
                     if archived.conf.type_.is_marp() {
                         if build_archived_html {
-                            if let Err(e) = copy_images_html(&project, &archived) {
+                            if let Err(e) =
+                                copy_images_html_with_options(&project, &archived, optimize_images)
+                            {
                                 log::error!(
                                     "Failed to copy archived images {}: {}",
                                     archived.dir.to_string_lossy(),
@@ -155,7 +186,12 @@ fn runner() -> anyhow::Result<()> {
                                 continue;
                             }
 
-                            match build_html_commands(&project, &archived) {
+                            match build_html_commands_with_options(
+                                &project,
+                                &archived,
+                                &optimize_options,
+                                optimize_images,
+                            ) {
                                 Ok(archived_cmds) => cmds.extend(archived_cmds),
                                 Err(e) => {
                                     log::error!(
@@ -166,7 +202,12 @@ fn runner() -> anyhow::Result<()> {
                                 }
                             }
 
-                            match build_ogp_image_commands(&project, &archived) {
+                            match build_ogp_image_commands_with_options(
+                                &project,
+                                &archived,
+                                &optimize_options,
+                                optimize_images,
+                            ) {
                                 Ok(archived_cmds) => cmds.extend(archived_cmds),
                                 Err(e) => {
                                     log::error!(
@@ -178,7 +219,12 @@ fn runner() -> anyhow::Result<()> {
                             }
                         }
 
-                        match build_pdf_commands(&project, &archived) {
+                        match build_pdf_commands_with_options(
+                            &project,
+                            &archived,
+                            &optimize_options,
+                            optimize_images,
+                        ) {
                             Ok(archived_cmds) => cmds.extend(archived_cmds),
                             Err(e) => {
                                 log::error!(
@@ -200,6 +246,35 @@ fn runner() -> anyhow::Result<()> {
 
             Ok(())
         }
+        Images { command } => match command {
+            ImagesCommands::Optimize {
+                dir,
+                dry_run,
+                force,
+            } => {
+                let slide = project.get_slide(&dir)?;
+                let report =
+                    optimize_slide_images(&project, &slide, &OptimizeOptions { dry_run, force })?;
+                print_report(&report, &project);
+                Ok(())
+            }
+            ImagesCommands::OptimizeAll { dry_run, force } => {
+                for slide in &project.slides {
+                    let report = optimize_slide_images(
+                        &project,
+                        slide,
+                        &OptimizeOptions { dry_run, force },
+                    )?;
+                    print_report(&report, &project);
+                }
+                Ok(())
+            }
+            ImagesCommands::Clean => {
+                let cache_dir = clean_image_cache(&project)?;
+                println!("Removed image cache: {}", cache_dir.to_string_lossy());
+                Ok(())
+            }
+        },
         Migrate { command } => match command {
             MigrateCommands::Plan { dir } => plan(&project, dir),
             MigrateCommands::Status => status(&project),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -32,6 +32,15 @@ pub enum SubCommands {
         /// max concurrent build
         #[clap(long, default_value = "4")]
         concurrent: usize,
+        /// skip image optimization before building
+        #[clap(long)]
+        no_optimize_images: bool,
+    },
+    /// Image operations
+    #[clap(arg_required_else_help = true)]
+    Images {
+        #[clap(subcommand)]
+        command: ImagesCommands,
     },
     /// Slide operations
     #[clap(arg_required_else_help = true)]
@@ -45,6 +54,33 @@ pub enum SubCommands {
         #[clap(subcommand)]
         command: MigrateCommands,
     },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ImagesCommands {
+    /// Optimize images referenced by a slide
+    Optimize {
+        /// path to slide directory
+        #[clap(required = true)]
+        dir: PathBuf,
+        /// show what would be optimized without writing files
+        #[clap(long)]
+        dry_run: bool,
+        /// ignore cached optimized files
+        #[clap(long)]
+        force: bool,
+    },
+    /// Optimize images referenced by all slides
+    OptimizeAll {
+        /// show what would be optimized without writing files
+        #[clap(long)]
+        dry_run: bool,
+        /// ignore cached optimized files
+        #[clap(long)]
+        force: bool,
+    },
+    /// Remove optimized image cache
+    Clean,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/path.rs
+++ b/src/path.rs
@@ -121,6 +121,7 @@ mod tests {
                     marp_binary: "marp".to_string(),
                     path_strategy,
                 },
+                images: Default::default(),
             },
             slides: vec![],
         }

--- a/src/subcommand/build.rs
+++ b/src/subcommand/build.rs
@@ -10,7 +10,11 @@ use colored::Colorize;
 use tokio::{process::Command, runtime::Runtime, sync::Semaphore};
 
 use crate::{
-    config::{PathStrategy, SlideConf},
+    config::{ImagesConf, PathStrategy, SlideConf},
+    images::{
+        optimize_slide_images, prepare_optimized_markdown, relative_path, ImageRewriteMode,
+        OptimizeOptions, OptimizeReport,
+    },
     path::{legacy_file_stems, PublishPlan},
     project::Project,
     slide::Slide,
@@ -137,25 +141,53 @@ pub fn build(commands: impl Iterator<Item = BuildCommand>, max_concurrent: usize
     });
 }
 
+#[cfg(test)]
 fn prepare_marp_input(
     project: &Project,
     slide: &Slide,
 ) -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
+    prepare_marp_input_with_options(
+        project,
+        slide,
+        &OptimizeOptions {
+            dry_run: false,
+            force: false,
+        },
+        false,
+        ImageRewriteMode::CacheRelativeToMarkdown,
+        None,
+    )
+}
+
+fn prepare_marp_input_with_options(
+    project: &Project,
+    slide: &Slide,
+    optimize_options: &OptimizeOptions,
+    optimize_images: bool,
+    rewrite_mode: ImageRewriteMode,
+    temp_dir: Option<&Path>,
+) -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
     let original_path = slide.dir.join("slide.md");
     let suffix = project.conf.template.suffix.trim_end();
 
-    if suffix.is_empty() {
+    if suffix.is_empty() && (!optimize_images || !project.conf.images.enabled) {
         return Ok((original_path, None));
     }
 
     let mut contents = fs::read_to_string(&original_path)?;
+    if optimize_images {
+        contents =
+            prepare_optimized_markdown(project, slide, &contents, optimize_options, rewrite_mode)?
+                .0;
+    }
+
     contents.push_str("\n\n");
     contents.push_str(suffix);
     contents.push('\n');
 
-    let temp_path = slide
-        .dir
-        .join(format!(".slide-flow-build-{}.md", uuid::Uuid::new_v4()));
+    let temp_dir = temp_dir.unwrap_or(&slide.dir);
+    std::fs::create_dir_all(temp_dir)?;
+    let temp_path = temp_dir.join(format!(".slide-flow-build-{}.md", uuid::Uuid::new_v4()));
     fs::write(&temp_path, contents)?;
 
     Ok((temp_path.clone(), Some(temp_path)))
@@ -195,12 +227,36 @@ pub fn build_pdf_commands<'a>(
     project: &'a Project,
     slide: &'a Slide,
 ) -> anyhow::Result<Vec<BuildCommand>> {
+    build_pdf_commands_with_options(
+        project,
+        slide,
+        &OptimizeOptions {
+            dry_run: false,
+            force: false,
+        },
+        true,
+    )
+}
+
+pub fn build_pdf_commands_with_options<'a>(
+    project: &'a Project,
+    slide: &'a Slide,
+    optimize_options: &OptimizeOptions,
+    optimize_images: bool,
+) -> anyhow::Result<Vec<BuildCommand>> {
     let output_stems = PublishPlan::for_slide(project, slide).versioned_pdf_stems;
     if output_stems.is_empty() {
         return Ok(vec![]);
     }
 
-    let (input_path, temp_input) = prepare_marp_input(project, slide)?;
+    let (input_path, temp_input) = prepare_marp_input_with_options(
+        project,
+        slide,
+        optimize_options,
+        optimize_images,
+        ImageRewriteMode::CacheRelativeToMarkdown,
+        None,
+    )?;
     let make_command = |output_stem: String| {
         let mut cmd = Command::new(&project.conf.build.marp_binary);
 
@@ -248,12 +304,36 @@ pub fn build_pdf_latest_alias_commands<'a>(
     project: &'a Project,
     slide: &'a Slide,
 ) -> anyhow::Result<Vec<BuildCommand>> {
+    build_pdf_latest_alias_commands_with_options(
+        project,
+        slide,
+        &OptimizeOptions {
+            dry_run: false,
+            force: false,
+        },
+        true,
+    )
+}
+
+pub fn build_pdf_latest_alias_commands_with_options<'a>(
+    project: &'a Project,
+    slide: &'a Slide,
+    optimize_options: &OptimizeOptions,
+    optimize_images: bool,
+) -> anyhow::Result<Vec<BuildCommand>> {
     let output_files = PublishPlan::for_slide(project, slide).latest_pdf_aliases;
     if output_files.is_empty() {
         return Ok(vec![]);
     }
 
-    let (input_path, temp_input) = prepare_marp_input(project, slide)?;
+    let (input_path, temp_input) = prepare_marp_input_with_options(
+        project,
+        slide,
+        optimize_options,
+        optimize_images,
+        ImageRewriteMode::CacheRelativeToMarkdown,
+        None,
+    )?;
     let make_command = |output_file_name: String| {
         let mut cmd = Command::new(&project.conf.build.marp_binary);
 
@@ -300,13 +380,29 @@ pub fn build_html_commands<'a>(
     project: &'a Project,
     slide: &'a Slide,
 ) -> anyhow::Result<Vec<BuildCommand>> {
+    build_html_commands_with_options(
+        project,
+        slide,
+        &OptimizeOptions {
+            dry_run: false,
+            force: false,
+        },
+        true,
+    )
+}
+
+pub fn build_html_commands_with_options<'a>(
+    project: &'a Project,
+    slide: &'a Slide,
+    optimize_options: &OptimizeOptions,
+    optimize_images: bool,
+) -> anyhow::Result<Vec<BuildCommand>> {
     let output_paths = PublishPlan::for_slide(project, slide).html_paths;
     if output_paths.is_empty() {
         return Ok(vec![]);
     }
 
-    let (input_path, temp_input) = prepare_marp_input(project, slide)?;
-    let make_command = |output_stem: String| {
+    let make_command = |output_stem: &str, input_path: &Path| {
         let mut cmd = Command::new(&project.conf.build.marp_binary);
 
         cmd.arg("--theme-set")
@@ -332,18 +428,43 @@ pub fn build_html_commands<'a>(
         cmd
     };
 
-    let len = output_paths.len();
-
-    Ok(output_paths
+    output_paths
         .into_iter()
-        .enumerate()
-        .map(|(index, path)| BuildCommand::HTML {
-            dir: slide.dir.clone(),
-            command: make_command(path),
-            conf: slide.conf.clone(),
-            temp_input: cleanup_temp_input(index, len, &temp_input),
+        .map(|path| {
+            let output_root = project.root_dir.join(&project.conf.output_dir).join(&path);
+            let rewrite_mode = if optimize_images && project.conf.images.enabled {
+                let shared_images_dir = project
+                    .root_dir
+                    .join(&project.conf.output_dir)
+                    .join(optimized_html_images_dir());
+                ImageRewriteMode::PublicAssets {
+                    base_dir: relative_path(&output_root, &shared_images_dir),
+                }
+            } else {
+                ImageRewriteMode::CacheRelativeToMarkdown
+            };
+            let temp_dir = if optimize_images && project.conf.images.enabled {
+                Some(output_root.as_path())
+            } else {
+                None
+            };
+            let (input_path, temp_input) = prepare_marp_input_with_options(
+                project,
+                slide,
+                optimize_options,
+                optimize_images,
+                rewrite_mode,
+                temp_dir,
+            )?;
+
+            Ok(BuildCommand::HTML {
+                command: make_command(&path, &input_path),
+                temp_input,
+                conf: slide.conf.clone(),
+                dir: slide.dir.clone(),
+            })
         })
-        .collect())
+        .collect()
 }
 
 /// generate build commands for OGP images
@@ -351,12 +472,36 @@ pub fn build_ogp_image_commands<'a>(
     project: &'a Project,
     slide: &'a Slide,
 ) -> anyhow::Result<Vec<BuildCommand>> {
+    build_ogp_image_commands_with_options(
+        project,
+        slide,
+        &OptimizeOptions {
+            dry_run: false,
+            force: false,
+        },
+        true,
+    )
+}
+
+pub fn build_ogp_image_commands_with_options<'a>(
+    project: &'a Project,
+    slide: &'a Slide,
+    optimize_options: &OptimizeOptions,
+    optimize_images: bool,
+) -> anyhow::Result<Vec<BuildCommand>> {
     let output_paths = PublishPlan::for_slide(project, slide).ogp_image_paths;
     if output_paths.is_empty() {
         return Ok(vec![]);
     }
 
-    let (input_path, temp_input) = prepare_marp_input(project, slide)?;
+    let (input_path, temp_input) = prepare_marp_input_with_options(
+        project,
+        slide,
+        optimize_options,
+        optimize_images,
+        ImageRewriteMode::CacheRelativeToMarkdown,
+        None,
+    )?;
     let make_command = |output_path: String| {
         let mut cmd = Command::new(&project.conf.build.marp_binary);
 
@@ -432,6 +577,31 @@ pub fn copy_ipe_pdf(
 
 /// copy images to output directory
 pub fn copy_images_html(project: &Project, slide: &Slide) -> anyhow::Result<()> {
+    copy_images_html_with_options(project, slide, true)
+}
+
+pub fn copy_images_html_with_options(
+    project: &Project,
+    slide: &Slide,
+    optimize_images: bool,
+) -> anyhow::Result<()> {
+    let report = if optimize_images && project.conf.images.enabled {
+        Some(optimize_slide_images(
+            project,
+            slide,
+            &OptimizeOptions {
+                dry_run: false,
+                force: false,
+            },
+        )?)
+    } else {
+        None
+    };
+
+    if let Some(report) = &report {
+        copy_optimized_images(project, report)?;
+    }
+
     for stem in PublishPlan::for_slide(project, slide).html_paths {
         let target_images_dir = project
             .root_dir
@@ -442,9 +612,14 @@ pub fn copy_images_html(project: &Project, slide: &Slide) -> anyhow::Result<()> 
         if target_images_dir.exists() {
             std::fs::remove_dir_all(&target_images_dir)?;
         }
-        std::fs::create_dir_all(&target_images_dir)?;
 
-        copy_images(slide, &target_images_dir)?;
+        let output_root = project.root_dir.join(&project.conf.output_dir).join(&stem);
+        remove_legacy_html_image_cache(&output_root, &project.conf.images)?;
+
+        if report.is_none() {
+            std::fs::create_dir_all(&target_images_dir)?;
+            copy_images(slide, &target_images_dir)?;
+        }
     }
 
     Ok(())
@@ -660,12 +835,51 @@ fn copy_images(slide: &Slide, target_images_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn remove_legacy_html_image_cache(
+    output_root: &Path,
+    images_conf: &ImagesConf,
+) -> anyhow::Result<()> {
+    let legacy_target_cache_dir = output_root.join(&images_conf.cache_dir);
+    if legacy_target_cache_dir.exists() {
+        std::fs::remove_dir_all(&legacy_target_cache_dir)?;
+    }
+
+    Ok(())
+}
+
+fn copy_optimized_images(project: &Project, report: &OptimizeReport) -> anyhow::Result<()> {
+    if report.is_empty() {
+        return Ok(());
+    }
+
+    let target_dir = project
+        .root_dir
+        .join(&project.conf.output_dir)
+        .join(optimized_html_images_dir());
+    std::fs::create_dir_all(&target_dir)?;
+
+    for image in &report.images {
+        let Some(file_name) = image.cache_path().file_name() else {
+            continue;
+        };
+        std::fs::copy(image.cache_path(), target_dir.join(file_name))?;
+    }
+
+    Ok(())
+}
+
+fn optimized_html_images_dir() -> PathBuf {
+    PathBuf::from("images").join("optimized")
+}
+
 #[cfg(test)]
 mod test_build {
     use super::{
         build_ogp_image_commands, prepare_marp_input, write_alias_redirects, BuildCommand,
     };
-    use crate::config::{BuildConf, PathStrategy, ProjectConf, SlideConf, SlideType, TemplateConf};
+    use crate::config::{
+        BuildConf, ImagesConf, PathStrategy, ProjectConf, SlideConf, SlideType, TemplateConf,
+    };
     use crate::project::Project;
     use crate::slide::Slide;
 
@@ -689,6 +903,7 @@ mod test_build {
                     suffix: String::new(),
                 },
                 build: BuildConf::default(),
+                images: ImagesConf::default(),
             },
             slides: vec![],
         };
@@ -734,6 +949,7 @@ mod test_build {
                     suffix: "<script src=\"/shared.js\"></script>".to_string(),
                 },
                 build: BuildConf::default(),
+                images: ImagesConf::default(),
             },
             slides: vec![],
         };
@@ -781,6 +997,7 @@ mod test_build {
                     marp_binary: "marp".to_string(),
                     path_strategy: PathStrategy::CanonicalWithRedirects,
                 },
+                images: ImagesConf::default(),
             },
             slides: vec![],
         };
@@ -870,6 +1087,7 @@ mod test_build {
                 output_dir: "output".to_string(),
                 template: TemplateConf::default(),
                 build: BuildConf::default(),
+                images: ImagesConf::default(),
             },
             slides: vec![],
         };

--- a/src/template.rs
+++ b/src/template.rs
@@ -156,6 +156,7 @@ mod test_template {
             output_dir: "output".to_string(),
             template,
             build: build_conf,
+            images: Default::default(),
         };
 
         let slides = vec![


### PR DESCRIPTION
## Summary
- Added functionality to optimize images during slide presentation builds,
including new subcommands for optimizing images and updating
documentation.

## Changed Areas
- `src/config.rs`: Updated to include image optimization configuration.
- `src/images.rs`: Added code for collecting image references, caching
optimized images, and applying optimizations using external tools.
- `src/lib.rs`, `src/main.rs`, `src/parser.rs`, `src/path.rs`,
`src/subcommand/build.rs`, `src/template.rs`: Integrated image
optimization into the build pipeline.

## User-visible Impact
- Users can optimize images during slide builds with new subcommands,
improving presentation quality and efficiency.

## Testing
- Not run (not shown in diff)

## Risks / Notes
- None apparent from diff